### PR TITLE
Pull Request: Add a unit test on anggaran application

### DIFF
--- a/anggaran/tests.py
+++ b/anggaran/tests.py
@@ -1,3 +1,25 @@
+from functools import wraps
+from unittest import mock
 from django.test import TestCase
+from .views import *
+
+mock_delete_expired = mock.MagicMock()
+mock_filter = mock.MagicMock()
 
 # Create your tests here.
+class AnggaranViewTest(TestCase):
+
+    def setup(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    @mock.patch('anggaran.views.delete_expired_anggaran', mock_delete_expired)
+    @mock.patch('anggaran.models.Anggaran.objects.filter', mock_filter)
+    def test_index_success(self):
+        mock_delete_expired.side_effect = [None]
+        mock_filter.return_value = []
+
+        response = self.client.get(reverse("anggaran:index"))
+        self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
### Description

This PR adds the **Unit Test** for the views of anggaran application.

### Changes
- Added a unit test for index view of the anggaran application in test.py.

### Issues
- **Unable to test further**:
Decorators were in the way of the view functions and was difficult for the unit test to pass through, causing it to not be covered by the test, based on the coverage report.
---